### PR TITLE
feat: Allow types to be imported from the other projects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT. See LICENSE file in the project root for full license information.
 
 
+export * from "./spec";
 export { load } from './load';
 export { clean } from './clean';
 export { restore } from './restore';

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -3,8 +3,8 @@
 
 
 export { defaults } from './defaults';
-export { Command } from './Command';
-export { CliOptions } from './CliOptions';
-export { CompiledConfig, Config, LifecycleEvents, MutationSets, ReplaceMap } from './Config';
-export { PackageJsonConfig } from './PackageJsonConfig';
-export { JsonDocument } from './Json';
+export type { Command } from './Command';
+export type { CliOptions } from './CliOptions';
+export type { CompiledConfig, Config, LifecycleEvents, MutationSets, ReplaceMap } from './Config';
+export type { PackageJsonConfig } from './PackageJsonConfig';
+export type { JsonDocument } from './Json';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
 		"strict": true,
 		"noImplicitAny": true,
 		"noImplicitThis": true,
-		"removeComments": false
+		"removeComments": false,
+		"isolatedModules": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
# What is the purpose of this Pull Request?

It resolves the issue where the types defined in your project cannot be imported.
I noticed it when trying to make an extendable config for my projects.

For example, once you try:

```ts
import type { Config } from "clean-package";
```

there's an error message:

>  Module '"clean-package"' declares 'Config' locally, but it is not exported.

---

By the way, thank you for this great tool! :heart: 
